### PR TITLE
Device Swap: mini-svs aft

### DIFF
--- a/local/soi/fkt_devices.yaml
+++ b/local/soi/fkt_devices.yaml
@@ -245,19 +245,19 @@ devices:
   ######################################
   minisvs_aft:
     category: "device"
-    device_type: "MiniSVST"
-    serial_number: "85418"
+    device_type: "MiniSVS"
+    serial_number: "35821"
     description: ""
 
     fields:
       Temperature: "MiniSVS_Aft_Temperature"
-      SoundVelocity: "MiniSVS_Aft_SoundVelocity"
+#    SoundVelocity: "MiniSVS_Aft_SoundVelocity"
 
   ######################################
   minisvs_fwd:
     category: "device"
     device_type: "MiniSVS"
-    serial_number: "35821"
+    serial_number: "44486"
     description: ""
 
     fields:


### PR DESCRIPTION
Changed out the MINI SVS-T  AFT  to a MINI SVS
made change in shipboard config as well to be merged. Being careful since I  am new to the new logger setup and didnt realize this had been split to seperate device so @KaarelRaeis-SOI  please review